### PR TITLE
Draft: [OpenMP] Fix `td_tdg_task_id` underflow with `taskloop` and `taskgraph`

### DIFF
--- a/openmp/runtime/src/kmp_tasking.cpp
+++ b/openmp/runtime/src/kmp_tasking.cpp
@@ -4952,7 +4952,8 @@ static void __kmp_taskloop(ident_t *loc, int gtid, kmp_task_t *task, int if_val,
   }
 
 #if OMPX_TASKGRAPH
-  KMP_ATOMIC_DEC(&__kmp_tdg_task_id);
+  if (taskdata->is_taskgraph)
+    KMP_ATOMIC_DEC(&__kmp_tdg_task_id);
 #endif
   // =========================================================================
   // calculate loop parameters


### PR DESCRIPTION
This patch addresses an issue where the `td_tdg_task_id` could underflow, leading to a negative task ID, when a `taskloop` region was encountered *before* a `taskgraph` clause.

Previously, `td_tdg_task_id` was decremented unconditionally within a `taskloop`, even if that `taskloop` was not part of an active `taskgraph`. This caused problems in scenarios like the following:

```cpp
#pragma omp parallel
#pragma omp single
{
// Here, td_tdg_task_id is incorrectly decremented, potentially becoming negative.
#pragma omp taskloop
  for (int i = 0; i < n; i++) {
    initialize(data[i]);
  }
}

#pragma omp parallel
#pragma omp single
{
#pragma omp taskgraph
{
// When this taskgraph is entered, the recording of tasks may fail (e.g., segfault)
// due to the invalid (negative) td_tdg_task_id.
#pragma omp taskloop
  for (int i = 0; i < num_iter;  i++) {
    compute();
  }
}
}
